### PR TITLE
Remove SplashClosed D-Bus signal, no longer used from the shell

### DIFF
--- a/data/com.endlessm.Speedwagon.xml
+++ b/data/com.endlessm.Speedwagon.xml
@@ -11,8 +11,5 @@
     <method name="HideSplash">
       <arg type="s" direction="in" name="desktopFile" />
     </method>
-    <signal name="SplashClosed">
-      <arg type="s" name="desktopFile" />
-    </signal>
   </interface>
 </node>

--- a/src/eos-speedwagon.c
+++ b/src/eos-speedwagon.c
@@ -284,7 +284,6 @@ speedwagon_window_delete_event (GtkWidget *widget,
   const char *desktop_id;
 
   desktop_id = g_app_info_get_id (G_APP_INFO (window->app_info));
-  eos_speedwagon_emit_splash_closed (self->skeleton, desktop_id);
   g_hash_table_remove (self->splashes, desktop_id);
 
   return GDK_EVENT_PROPAGATE;


### PR DESCRIPTION
Relying on this signal in the shell to know when to request
quitting an application is racy. We won't use it anymore and
rely on notifications from the window manager instead.

https://phabricator.endlessm.com/T20725